### PR TITLE
Doing so increases compatibility with MyLezeem/puppet-authconfig

### DIFF
--- a/templates/nslcd.erb
+++ b/templates/nslcd.erb
@@ -6,7 +6,7 @@ uid <%= @uid %>
 gid <%= @gid %>
 
 # The location at which the LDAP server(s) should be reachable.
-uri <% @ldap_uris.sort.each do |ldap_uri| -%><%= ldap_uri -%> <% end -%>
+uri <%= @ldap_uris.join(' ').sort %>
 
 # The LDAP protocol version to use.
 ldap_version <%= @ldap_version %>


### PR DESCRIPTION
(https://github.com/Mylezeem/puppet-authconfig) module.  Since the
authconfig module will modify /etc/nslcd.conf, a flapping situation will
occur that causes nslcd to restart because the trailing space was
removed by 'authconfig --updateall'.

Standard Linux 'authconfig' will remove the trailing space from /etc/nslcd.conf, causing the nslcd daemon to restart on every puppet run.

This fix removes the trailing space AND sorts the URIs alphabetically.